### PR TITLE
Arreglar script para inicializar las BDs

### DIFF
--- a/tp2/ej11/imagen-bancos/script_tabla_cuentas.sql
+++ b/tp2/ej11/imagen-bancos/script_tabla_cuentas.sql
@@ -1,6 +1,4 @@
-﻿create role jtatest LOGIN password 'jtatest';
-
-CREATE TABLE cuentas(
+﻿CREATE TABLE cuentas(
     id integer PRIMARY KEY, 
     titular character(30) NOT NULL,
     fecha_creacion timestamp with time zone DEFAULT now(),
@@ -8,8 +6,12 @@ CREATE TABLE cuentas(
     saldo real
 );
 
-ALTER TABLE public.cuentas OWNER TO postgres;
-GRANT SELECT,INSERT ON TABLE cuentas TO jtatest;
+/*
+ * Estos ALTER y GRANT van comentados porque al contenedor no le gusta :/ 
+ */
+-- create role jtatest LOGIN password 'jtatest';
+-- ALTER TABLE public.cuentas OWNER TO postgres;
+-- GRANT SELECT,INSERT ON TABLE cuentas TO jtatest;
 
 INSERT INTO cuentas (id,titular,bloqueada,saldo) 
   VALUES (1, 'Cliente 1',True,0); 
@@ -21,3 +23,5 @@ INSERT INTO cuentas (id,titular,bloqueada,saldo)
   VALUES (4, 'Cliente 4',False,3000);
 INSERT INTO cuentas (id,titular,bloqueada,saldo) 
   VALUES (5, 'Cliente 5',False,4000); 
+
+SELECT * FROM cuentas;


### PR DESCRIPTION
Había unas cosas en el script que asignaba permisos al usuario `postgres` que al contenedor no le gustaba una mierda, así que se fueron