### PR TITLE
Modificar refresco del chat

### DIFF
--- a/tp3/ej5/cgi-bin/chat.py
+++ b/tp3/ej5/cgi-bin/chat.py
@@ -125,14 +125,13 @@ def get_messages(starting=0):
                 # Bloquear archivo
                 fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
                 _messages = []
-                for i, l in enumerate(f.readlines()):
-                    if i >= starting:
-                        l = l.replace("\n", "").replace("\r", "").split(":")
-                        l = [line.strip() for line in l]
-                        _messages.append({
-                            "user": l[0],
-                            "message": l[1]
-                        })
+                for l in f.readlines()[starting:]:
+                    l = l.replace("\n", "").replace("\r", "").split(":")
+                    l = [line.strip() for line in l]
+                    _messages.append({
+                        "user": l[0],
+                        "message": l[1]
+                    })
                 # Liberar archivo
                 fcntl.flock(f, fcntl.LOCK_UN)
                 return _messages

--- a/tp3/ej5/cgi-bin/chat.py
+++ b/tp3/ej5/cgi-bin/chat.py
@@ -14,7 +14,7 @@ from tempfile import NamedTemporaryFile
 from utils.utils import \
     get_template, print_headers, _get_last_line, file_is_empty
 from utils.log import log
-from session.session import get_cookie_value
+from session.session import get_cookie_value, parse_cookie
 from session.login import login, logout
 
 
@@ -181,7 +181,8 @@ def get_active_users(session_filename):
 
 def get():
     session_id = get_cookie_value(COOKIE_NAME)
-    session = get_session(session_id, SESSIONFILE)
+    _id, last_line = parse_cookie(session_id)
+    session = get_session(_id, SESSIONFILE)
     form = cgi.FieldStorage()
 
     if session:
@@ -225,7 +226,8 @@ def get():
 
 def post():
     session_id = get_cookie_value(COOKIE_NAME)
-    session = get_session(session_id, SESSIONFILE)
+    _id, last_line = parse_cookie(session_id)
+    session = get_session(_id, SESSIONFILE)
     form = cgi.FieldStorage()
     if session:
         # El usuario está logueado

--- a/tp3/ej5/cgi-bin/chat.py
+++ b/tp3/ej5/cgi-bin/chat.py
@@ -56,7 +56,7 @@ def create_session(username, session_filename):
     _session = {
         "id": str(uuid4()),
         "user": username,
-        "last_line": _get_last_line(CHATFILE)["count"]
+        "last_line": _get_last_line(CHATFILE)["count"]+1
     }
     while True:
         try:

--- a/tp3/ej5/cgi-bin/session/session.py
+++ b/tp3/ej5/cgi-bin/session/session.py
@@ -54,6 +54,12 @@ def get_cookie_value(name):
         # No cookies available
         return None
 
+def parse_cookie(cookie_value):
+    """Devuelve (session_id, last_line) a partir de la cookie"""
+    try:
+        return cookie_value.split("|")
+    except (TypeError, AttributeError) as e:
+        return None, None
 
 def remove_auth_cookie(name):
     """

--- a/tp3/ej5/cgi-bin/utils/utils.py
+++ b/tp3/ej5/cgi-bin/utils/utils.py
@@ -11,7 +11,7 @@ def get_template(template_name, templates_dir="./templates"):
     return ctx.get_template(template_name)
 
 def _get_last_line(filename):
-    """Devuelve la última línea de un archivo"""
+    """Devuelve la última línea de un archivo (comenzando desde 1)"""
     import fcntl
     try:
         with open(filename) as f:
@@ -21,7 +21,7 @@ def _get_last_line(filename):
             # Liberar archivo
             fcntl.flock(f, fcntl.LOCK_UN)
             return {
-                "count": len(lines),
+                "count": len(lines)-1,
                 "line": lines[-1]
             }
     except FileNotFoundError as e:

--- a/tp3/ej5/static/js/src/chat.js
+++ b/tp3/ej5/static/js/src/chat.js
@@ -61,7 +61,7 @@ const onClickMessageSend = (evt) => {
 const onRefreshMessages = () => { 
   /* Manejador para el refresco de los mensajes */
   const msgsCount = getMessagesCount();
-  fetch(`?starting=${msgsCount}`, {
+  fetch(`?refresh=true`, {
     credentials: "include",
   })
     .then(res => res.text())
@@ -69,14 +69,20 @@ const onRefreshMessages = () => {
       const parser = new DOMParser();
       const html = parser.parseFromString(res, "text/html");
       try {
+
+        //Actualizar mensajes
         const messages = 
-          Array.from(html.querySelector("#messages-list").children);
+          Array.from(html.querySelector("#messages-list").children)
         messages.forEach(msg => {
           document.querySelector("#messages-list").appendChild(msg);
         });
-        scrollToBottom(".messages");
+
+        //Actualizar usuarios
         document.querySelector("#users-list").innerHTML = 
           html.querySelector("#users-list").innerHTML;
+
+        //Scrollear hasta el último mensaje
+        scrollToBottom(".messages");
       } catch (e) {
         //Como la #messages-list puede estar vacía, 
         //va tirar excepción al querer acceder a ".children"

--- a/tp3/ej5/static/js/src/chat.js
+++ b/tp3/ej5/static/js/src/chat.js
@@ -4,12 +4,10 @@ const REFRESH_INTERVAL = 1000 * 2;
 
 const getRefreshInterval = () => { return REFRESH_INTERVAL; };
 
-const addMessage = ({username, message}) => {
+const addMessage = (message) => {
   /* Agrega un mensaje a la ventana de chat */
-  const messagesUl = document.querySelector("#messages-list");
-  const newMessage = document.createElement("li");
-  newMessage.innerHTML = `<b>${username}</b>: ${message.message}`;
-  messagesUl.appendChild(newMessage);
+  console.log({message});
+  document.querySelector("#messages-list").appendChild(message);
 };
 
 
@@ -47,9 +45,12 @@ const onClickMessageSend = (evt) => {
       "Content-type": "application/x-www-form-urlencoded"
     }
   })
-    .then(_ => {
-      const username = document.querySelector("#username").innerText;
-      addMessage({username, message});
+    .then(res => res.text())
+    .then(message => {
+      const parser = new DOMParser();
+      const messageAsLi = parser.parseFromString(message, "text/html")
+        .querySelector("li");
+      addMessage(messageAsLi);
       cleanInput("#message-form input");
       scrollToBottom(".messages");
     })


### PR DESCRIPTION
Arreglar refresco del chat (#47)

- El cliente pide los mensajes nuevo cada 2 segundos y el servidor le envía solamente los mensajes
- Si el cliente hace un refresh de la página, sigue viendo los mismos mensajes que tenía. No puede ver todo el chat